### PR TITLE
feat(runtime): configurable per-tool-result truncation cap

### DIFF
--- a/runtime/cap.go
+++ b/runtime/cap.go
@@ -1,0 +1,27 @@
+package runtime
+
+import (
+	"os"
+	"strconv"
+)
+
+// maxToolResultLen returns the per-result truncation cap (chars) for tool
+// results in the in-context message history. Precedence:
+//  1. Runtime.AgentLoop.MaxToolResultLen (>0) — config wins.
+//  2. HARNESS_MAX_TOOL_RESULT_LEN env var (>0) — env fallback.
+//  3. defaultMaxToolResultLen (4000).
+//
+// Tool results longer than this are truncated (or spilled to disk via
+// spillConfig when supplied). 4000 is conservative; engineering-style
+// agents that read source files and run tests typically want 16000-25000.
+func (r *Runtime) maxToolResultLen() int {
+	if r.AgentLoop.MaxToolResultLen > 0 {
+		return r.AgentLoop.MaxToolResultLen
+	}
+	if v := os.Getenv("HARNESS_MAX_TOOL_RESULT_LEN"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultMaxToolResultLen
+}

--- a/runtime/cap_test.go
+++ b/runtime/cap_test.go
@@ -1,0 +1,50 @@
+package runtime
+
+import (
+	"testing"
+)
+
+// TestMaxToolResultLen_Precedence locks in the config > env > default
+// precedence so a regression here doesn't silently swap one source for
+// another.
+func TestMaxToolResultLen_Precedence(t *testing.T) {
+	t.Run("default when nothing set", func(t *testing.T) {
+		t.Setenv("HARNESS_MAX_TOOL_RESULT_LEN", "")
+		r := &Runtime{}
+		if got := r.maxToolResultLen(); got != defaultMaxToolResultLen {
+			t.Fatalf("want %d, got %d", defaultMaxToolResultLen, got)
+		}
+	})
+
+	t.Run("env overrides default", func(t *testing.T) {
+		t.Setenv("HARNESS_MAX_TOOL_RESULT_LEN", "12345")
+		r := &Runtime{}
+		if got := r.maxToolResultLen(); got != 12345 {
+			t.Fatalf("want 12345, got %d", got)
+		}
+	})
+
+	t.Run("config overrides env", func(t *testing.T) {
+		t.Setenv("HARNESS_MAX_TOOL_RESULT_LEN", "12345")
+		r := &Runtime{AgentLoop: LoopConfig{MaxToolResultLen: 25000}}
+		if got := r.maxToolResultLen(); got != 25000 {
+			t.Fatalf("want 25000, got %d", got)
+		}
+	})
+
+	t.Run("zero env is ignored", func(t *testing.T) {
+		t.Setenv("HARNESS_MAX_TOOL_RESULT_LEN", "0")
+		r := &Runtime{}
+		if got := r.maxToolResultLen(); got != defaultMaxToolResultLen {
+			t.Fatalf("want %d, got %d", defaultMaxToolResultLen, got)
+		}
+	})
+
+	t.Run("garbage env is ignored", func(t *testing.T) {
+		t.Setenv("HARNESS_MAX_TOOL_RESULT_LEN", "not-a-number")
+		r := &Runtime{}
+		if got := r.maxToolResultLen(); got != defaultMaxToolResultLen {
+			t.Fatalf("want %d, got %d", defaultMaxToolResultLen, got)
+		}
+	})
+}

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -13,7 +13,12 @@ import (
 	"github.com/sausheong/harness/session"
 )
 
-const maxToolResultLen = 4000 // truncate tool results longer than this
+// defaultMaxToolResultLen is the fallback cap used when LoopConfig.MaxToolResultLen
+// is unset and the HARNESS_MAX_TOOL_RESULT_LEN env var is unset/invalid. Tool
+// results longer than this get truncated (or spilled to disk + truncated-with-
+// marker when spillConfig is supplied). 4000 chars (~1000 tokens) is conservative
+// so behaviour is unchanged for callers that don't opt into a larger budget.
+const defaultMaxToolResultLen = 4000
 
 // detectImageMIME returns the actual MIME type based on magic bytes.
 // Falls back to the provided hint if the format is unrecognized.

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -364,7 +364,7 @@ func (r *Runtime) Run(ctx context.Context, userMsg string, images []llm.ImageCon
 			msgs := assembleMessages(history)
 
 			spillCfg := spillConfig{Workspace: r.Workspace, SessionKey: r.Session.Key}
-			pruneToolResults(msgs, maxToolResultLen, spillCfg)
+			pruneToolResults(msgs, r.maxToolResultLen(), spillCfg)
 
 			toolDefs := r.Tools.ToolDefs()
 			if r.Permission != nil {
@@ -390,7 +390,7 @@ func (r *Runtime) Run(ctx context.Context, userMsg string, images []llm.ImageCon
 					r.emit(AgentEvent{Type: EventCompactionDone, Compaction: &res})
 					history = r.Session.View()
 					msgs = assembleMessages(history)
-					pruneToolResults(msgs, maxToolResultLen, spillCfg)
+					pruneToolResults(msgs, r.maxToolResultLen(), spillCfg)
 					msgs = prependPostCompactRestore(msgs, r.snapshotTouchedFiles())
 				}
 			}
@@ -416,7 +416,7 @@ func (r *Runtime) Run(ctx context.Context, userMsg string, images []llm.ImageCon
 						r.emit(AgentEvent{Type: EventCompactionDone, Compaction: &res})
 						history = r.Session.View()
 						msgs = assembleMessages(history)
-						pruneToolResults(msgs, maxToolResultLen, spillCfg)
+						pruneToolResults(msgs, r.maxToolResultLen(), spillCfg)
 						msgs = prependPostCompactRestore(msgs, r.snapshotTouchedFiles())
 					} else {
 						r.emit(AgentEvent{Type: EventCompactionSkipped, Compaction: &res})
@@ -449,7 +449,7 @@ func (r *Runtime) Run(ctx context.Context, userMsg string, images []llm.ImageCon
 						r.emit(AgentEvent{Type: EventCompactionDone, Compaction: &res})
 						history = r.Session.View()
 						msgs = assembleMessages(history)
-						pruneToolResults(msgs, maxToolResultLen, spillCfg)
+						pruneToolResults(msgs, r.maxToolResultLen(), spillCfg)
 						msgs = prependPostCompactRestore(msgs, r.snapshotTouchedFiles())
 						req.Messages = msgs
 						stream, err = r.LLM.ChatStream(ctx, req)

--- a/runtime/types.go
+++ b/runtime/types.go
@@ -71,6 +71,14 @@ type LoopConfig struct {
 	// StreamingTools enables mid-stream concurrency-safe tool kickoff.
 	// false ⇒ env fallback (HARNESS_STREAMING_TOOLS=1) then off.
 	StreamingTools bool
+	// MaxToolResultLen caps the in-context length of any single tool
+	// result; longer results are truncated to their first MaxToolResultLen
+	// chars (cut at a newline boundary) with the remainder either spilled
+	// to disk via spillConfig or simply dropped. 0 ⇒ env fallback
+	// (HARNESS_MAX_TOOL_RESULT_LEN) then default 4000. Common pick for
+	// engineering-style agents (reading source files, running tests) is
+	// 16000-25000.
+	MaxToolResultLen int
 	// Hooks are optional callbacks the runtime fires at well-known
 	// points in the loop. Zero value (all nil fields) disables every
 	// hook with no overhead.


### PR DESCRIPTION
## Summary
Adds \`LoopConfig.MaxToolResultLen\` so callers can override the hardcoded 4000-char cap that \`pruneToolResults\` enforces on every tool result in the in-context message history.

Precedence matches the existing \`MaxToolConcurrency\` / \`MaxAgentDepth\` knobs:

1. \`Runtime.AgentLoop.MaxToolResultLen\` (>0) — config wins.
2. \`HARNESS_MAX_TOOL_RESULT_LEN\` env var (>0) — env fallback.
3. \`defaultMaxToolResultLen\` (4000) — **unchanged** for back-compat.

## Why
4000 chars (~1000 tokens) is conservative for agents doing engineering work — a single source file read or test-run output blows past it, forcing constant spill/re-fetch round-trips. A 16K-25K cap matches what most real workloads need; spill remains the safety net for outliers.

## Test plan
- [x] \`go test ./runtime -run TestMaxToolResultLen -v\` — five subtests cover default / env / config / zero-env / garbage-env precedence.
- [x] \`go test ./... -timeout 60s\` — full suite green.
- [x] No behaviour change for callers that leave \`MaxToolResultLen\` at zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)