### PR TITLE
fix: send adaptive thinking to Claude Opus 5 and Sonnet 5

### DIFF
--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -469,6 +469,8 @@ func anthropicAdaptiveThinkingOnly(model string) bool {
 		"claude-opus-4-7",
 		"claude-opus-4-8",
 		"claude-opus-4-9", // future-proof within the 4.x line
+		"claude-opus-5",
+		"claude-sonnet-5",
 	}
 	for _, marker := range adaptiveOnly {
 		if strings.Contains(model, marker) {


### PR DESCRIPTION
`anthropicAdaptiveThinkingOnly` covers Fable 5, Mythos, and Opus 4.7/4.8 but not `claude-opus-5` / `claude-sonnet-5`, so requests to those models get the legacy `{type: "enabled", budget_tokens: N}` thinking config, which the Claude 5 family rejects:

```
400 invalid_request_error: "thinking.type.enabled" is not supported for this model.
Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.
```

Net effect: every request routed to either model fails. Repro'd on v0.3.4 running Octopus with Claude Code against an Anthropic-shaped gateway (LiteLLM → Vertex); verified fixed with this change. Substring matching already covers gateway model-group names (`claude-sonnet-5-global`) and Bedrock-style IDs, same as the existing entries.